### PR TITLE
Add LoggerPackages configuration 

### DIFF
--- a/logone/logger.go
+++ b/logone/logger.go
@@ -71,8 +71,11 @@ func (l *Logger) Finish() {
 	fmt.Println(string(logline))
 }
 
+// skip logone package
+const minSkipFileInfo = 3
+
 func (l *Logger) Record(severity Severity, message string) *LogEntry {
-	funcname, _, fileline := FileInfo(3)
+	funcname, _, fileline := l.FileInfo(minSkipFileInfo + l.Config.CallerSkip)
 	e := &LogEntry{
 		Severity: severity,
 		Message:  message,
@@ -102,12 +105,16 @@ func (l *Logger) Critical(f string, v ...interface{}) *LogEntry {
 	return l.Record(SeverityCritical, fmt.Sprintf(f, v...))
 }
 
-func FileInfo(depth int) (string, string, int) {
-	pc, _, _, ok := runtime.Caller(depth)
+func (l *Logger) FileInfo(skip int) (string, string, int) {
+	pc, _, _, ok := runtime.Caller(skip)
 	if !ok {
 		return "???", "???", 0
 	}
+
 	fn := runtime.FuncForPC(pc)
+	funcname := fn.Name()
+
 	filename, fileline := fn.FileLine(pc)
-	return fn.Name(), filename, fileline
+
+	return funcname, filename, fileline
 }

--- a/logone/manager.go
+++ b/logone/manager.go
@@ -11,6 +11,7 @@ type Config struct {
 	OutputSeverity  Severity
 	JsonIndent      bool
 	ElapsedUnit     time.Duration
+	CallerSkip      int
 }
 
 type Manager struct {


### PR DESCRIPTION
I added `LoggerPackages` to the logger config.

`logone` usually skips its own information in log's func-name or file-line attributes . However, if we add a logger that wraps logone, the wrapper's information will be recorded as the caller. So, I implemented that , if the package name of the logger is added to the configuration, the package will be skipped as well as logone.

## Usage
Configuration
```go
logger := logone.NewLogger(
        &logone.Config{
	        Type:  "request",
		DefaultSeverity: logone.Debug,
		JsonIndent:      true,
		ElapsedUnit:     time.Millisecond,
		LoggerPackages:  []string{"github.com/gami/mylogger"},
        }
)
```

before
```go
"lines": [
    {
        "severity": "INFO",
        "message": "test",
        "time": "2021-12-05T03:17:23.412121216+09:00",
        "fileline": 42,
        "funcname": "github.com/gami/mylogger.(*MyLogger).Info"
    },
```

after
```go
"lines": [
    {
        "severity": "INFO",
        "message": "test",
        "time": "2021-12-05T03:17:23.412121216+09:00",
        "fileline": 42,
        "funcname": "my/app.(*Action).Do"
    },
```
